### PR TITLE
Allow to track and handle errors RIS-754

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,3 +1,15 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
+  plugins: [
+    [
+      'module-resolver',
+      {
+        root: ['./'],
+        alias: {
+          '@src': './src', // Add the alias configuration
+        },
+        extensions: ['.js', '.jsx', '.ts', '.tsx'], // Extensions to resolve
+      },
+    ],
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@testing-library/react-native": "^12.6.1",
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.44",
+    "babel-plugin-module-resolver": "^5.0.2",
     "commitlint": "^17.0.2",
     "del-cli": "^5.1.0",
     "eslint": "^8.51.0",
@@ -101,7 +102,9 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|svg)$": "identity-obj-proxy"
     },
-    "setupFilesAfterEnv": ["<rootDir>/jest-setup.ts"]
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest-setup.ts"
+    ]
   },
   "commitlint": {
     "extends": [

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, type ReactNode } from 'react';
+import * as Errors from './services/Errors';
+import { Text } from 'react-native';
+
+type ErrorBoundaryProps = {
+  fallback?: string;
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  // This method is called when a child component throws an error
+  static getDerivedStateFromError(_error: Error): ErrorBoundaryState {
+    // Update state to show the fallback UI
+    return { hasError: true };
+  }
+
+  // This method is called to log the error or perform side effects
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    Errors.handle(
+      ['Error caught by ErrorBoundary:', error, errorInfo].join('; ')
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <>{this.props.fallback && <Text>{this.props.fallback}</Text>}</>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/__tests__/ClaimsList/index.test.tsx
+++ b/src/__tests__/ClaimsList/index.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react-native';
-import { ClaimsList } from '..';
+import { ClaimsList } from '../../trustBadge/ClaimsList';
 import React from 'react';
 
 const validImageUrl = (number: number) => `https://cdn.io/img${number}`;

--- a/src/__tests__/ClaimsList/index.test.tsx
+++ b/src/__tests__/ClaimsList/index.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react-native';
-import { ClaimsList } from '../../trustBadge/ClaimsList';
+import { ClaimsList } from '@src/trustBadge/ClaimsList';
 import React from 'react';
 
 const validImageUrl = (number: number) => `https://cdn.io/img${number}`;

--- a/src/__tests__/api/index.test.tsx
+++ b/src/__tests__/api/index.test.tsx
@@ -1,4 +1,4 @@
-import { offersSuccess } from '../../__fixtures__/offers';
+import { offersNoProofPoints, offersSuccess } from '../../__fixtures__/offers';
 import { getOffers, configure } from '../../api';
 
 global.console = {
@@ -53,6 +53,22 @@ describe('getOffers', () => {
       expect(result).toBeNull();
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected response')
+      );
+    });
+  });
+
+  describe('when proof points were not found', () => {
+    it('is not shown', async () => {
+      global.fetch = jest.fn(() => ({
+        ok: true,
+        json: () => Promise.resolve(offersNoProofPoints()),
+      })) as jest.Mock;
+
+      const result = await getOffers('fakeSku');
+
+      expect(result).toEqual(offersNoProofPoints());
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No proof points found for the SKU: fakeSku')
       );
     });
   });

--- a/src/__tests__/api/index.test.tsx
+++ b/src/__tests__/api/index.test.tsx
@@ -1,5 +1,6 @@
-import { offersNoProofPoints, offersSuccess } from '../../__fixtures__/offers';
-import { getOffers, configure } from '../../api';
+import { offersNoProofPoints, offersSuccess } from '@src/__fixtures__/offers';
+import { getOffers, configure } from '@src/api';
+import * as Errors from '@src/services/Errors';
 
 global.console = {
   ...console,
@@ -12,6 +13,12 @@ const sampleApiKey = 'test-api-key';
 configure({ apiHost: 'staging', key: sampleApiKey });
 
 describe('getOffers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Errors, 'handle');
+    jest.spyOn(Errors, 'warn');
+  });
+
   it('calls the API', async () => {
     global.fetch = jest.fn(() => ({
       ok: true,
@@ -35,7 +42,7 @@ describe('getOffers', () => {
       const result = await getOffers('a-sku');
 
       expect(result).toBeNull();
-      expect(console.error).toHaveBeenCalledWith(
+      expect(Errors.handle).toHaveBeenCalledWith(
         expect.stringContaining('Bad gateway')
       );
     });
@@ -51,7 +58,7 @@ describe('getOffers', () => {
       const result = await getOffers('a-sku');
 
       expect(result).toBeNull();
-      expect(console.error).toHaveBeenCalledWith(
+      expect(Errors.handle).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected response')
       );
     });
@@ -67,7 +74,7 @@ describe('getOffers', () => {
       const result = await getOffers('fakeSku');
 
       expect(result).toEqual(offersNoProofPoints());
-      expect(console.warn).toHaveBeenCalledWith(
+      expect(Errors.warn).toHaveBeenCalledWith(
         expect.stringContaining('No proof points found for the SKU: fakeSku')
       );
     });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -101,4 +101,29 @@ describe('TrustBadge', () => {
       });
     });
   });
+
+  describe('when error raised', () => {
+    it('is not shown', () => {
+      mockGetOffers.mockImplementation(() => {
+        throw new Error('Unhandled error');
+      });
+      expect(() => whenTrustBadgeRendered()).not.toThrow();
+
+      expect(screen.root).not.toHaveTextContent(/Sustainability claims/i);
+    });
+  });
+
+  describe('with wrong params', () => {
+    it('gently notifies developer', () => {
+      expect(() => {
+        whenTrustBadgeRendered('UnsupportedVariant');
+      }).not.toThrow();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Trust badge variant "UnsupportedVariant" is invalid'
+        )
+      );
+    });
+  });
 });

--- a/src/__tests__/services/Errors.test.tsx
+++ b/src/__tests__/services/Errors.test.tsx
@@ -1,0 +1,31 @@
+import { configure } from '@src/api';
+import * as Errors from '@src/services/Errors';
+
+global.console = {
+  ...console,
+  error: jest.fn(),
+};
+
+const anError = new Error('Whoa!');
+
+describe('Errors', () => {
+  describe('handle', () => {
+    it('writes to errors log', () => {
+      Errors.handle(anError);
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('[Provenance] Error: Whoa!')
+      );
+    });
+  });
+
+  describe('when onError callback configured', () => {
+    it('passes the error to the callback', () => {
+      const onError = jest.fn();
+      configure({ onError, key: 'a-key' });
+      Errors.handle(anError);
+
+      expect(onError).toHaveBeenCalledWith(anError);
+    });
+  });
+});

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -66,7 +66,7 @@ export async function getOffers(sku: string): Promise<OffersData | null> {
       const data = await response.json();
       if (!data.proofPoints) {
         console.error(
-          'Unexpected response. Looks like API endpoint having a problem please let us know if the issues persists.'
+          'Unexpected response. Looks like API endpoint having a problem please let us know if the issue persists.'
         );
         return null;
       }

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,4 +1,5 @@
 import * as Errors from '../services/Errors';
+import { type OnErrorCallback } from '../services/Errors';
 
 const hosts = {
   production: 'https://provenance.org',
@@ -13,17 +14,22 @@ let apiKey: string = '';
 type ApiHost = 'staging' | 'production' | string;
 
 type ConfigurationOptions = {
-  apiHost?: ApiHost;
   key: string;
+  apiHost?: ApiHost;
+  onError?: OnErrorCallback;
 };
 
 export const configure = (options: ConfigurationOptions) => {
+  setApiKey(options.key);
+
   if (options.apiHost) {
     console.log('Setting host to:', options.apiHost);
     setHost(options.apiHost);
   }
 
-  setApiKey(options.key);
+  if (options.onError) {
+    Errors.setOnErrorCallback(options.onError);
+  }
 };
 
 function setHost(apiHost: ApiHost) {

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,3 +1,5 @@
+import * as Errors from '../services/Errors';
+
 const hosts = {
   production: 'https://provenance.org',
   staging: 'https://staging.provenance.org',
@@ -65,24 +67,24 @@ export async function getOffers(sku: string): Promise<OffersData | null> {
     if (response.ok) {
       const data = await response.json();
       if (!data.proofPoints) {
-        console.error(
+        Errors.handle(
           'Unexpected response. Looks like API endpoint having a problem please let us know if the issue persists.'
         );
         return null;
       }
       if (data.proofPoints.length === 0) {
-        console.warn(
+        Errors.warn(
           `No proof points found for the SKU: ${sku}, it could be a valid case but better double check that the SKU is valid.`
         );
       }
       return data;
     } else {
       const message = await response.text();
-      console.error(`Response failed. ${response.status} ${message}`);
+      Errors.handle(`Response failed. ${response.status} ${message}`);
       return null;
     }
   } catch (e) {
-    console.error(e);
+    Errors.handle(e as Error);
     return null;
   }
 }

--- a/src/bundle/index.tsx
+++ b/src/bundle/index.tsx
@@ -7,6 +7,8 @@ import type {
   WebViewErrorEvent,
   WebViewMessageEvent,
 } from 'react-native-webview/lib/WebViewTypes';
+import ErrorBoundary from '../ErrorBoundary';
+import * as Errors from '../services/Errors';
 
 const handleShouldStartLoadWithRequest = (request: any) => {
   // Intercept URL loading
@@ -39,7 +41,7 @@ export const minModalHeight = 540;
 
 export const loadingHeight = 175;
 
-export function Bundle({
+function BundleComponent({
   bundleId,
   sku,
   onModalShown,
@@ -60,7 +62,7 @@ export function Bundle({
         nestedScrollEnabled={true}
         onError={(syntheticEvent: WebViewErrorEvent) => {
           const { nativeEvent } = syntheticEvent;
-          console.warn('WebView error: ', nativeEvent);
+          Errors.handle(`WebView error: ${nativeEvent}`);
         }}
         injectedJavaScript={`
           window.ReactNativeWebView.postMessage("JS injected");
@@ -120,6 +122,14 @@ export function Bundle({
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
       />
     </View>
+  );
+}
+
+export function Bundle(props: BundleProps) {
+  return (
+    <ErrorBoundary fallback="Something went wrong">
+      <BundleComponent {...props} />
+    </ErrorBoundary>
   );
 }
 

--- a/src/bundle/index.tsx
+++ b/src/bundle/index.tsx
@@ -6,6 +6,7 @@ import { bundleUrl } from '../api';
 import type {
   WebViewErrorEvent,
   WebViewMessageEvent,
+  WebViewRenderProcessGoneEvent,
 } from 'react-native-webview/lib/WebViewTypes';
 import ErrorBoundary from '../ErrorBoundary';
 import * as Errors from '../services/Errors';
@@ -63,6 +64,12 @@ function BundleComponent({
         onError={(syntheticEvent: WebViewErrorEvent) => {
           const { nativeEvent } = syntheticEvent;
           Errors.handle(`WebView error: ${nativeEvent}`);
+        }}
+        onRenderProcessGone={(
+          syntheticEvent: WebViewRenderProcessGoneEvent
+        ) => {
+          const { nativeEvent } = syntheticEvent;
+          Errors.handle(`WebView crashed: ${nativeEvent.didCrash}`);
         }}
         injectedJavaScript={`
           window.ReactNativeWebView.postMessage("JS injected");

--- a/src/bundle/webviewErrorHandler.tsx
+++ b/src/bundle/webviewErrorHandler.tsx
@@ -1,0 +1,22 @@
+import { type NativeSyntheticEvent } from 'react-native';
+import * as Errors from '../services/Errors';
+
+class ProvenanceWebviewError extends Error {
+  constructor(message: string, event: any) {
+    let eventDetails: string = '';
+    try {
+      eventDetails = JSON.stringify(event);
+    } catch (e) {
+      eventDetails =
+        'Could not stringify event, please inspect cause on the error';
+    }
+    super([message, eventDetails].join(': '), { cause: event });
+  }
+}
+
+export function webviewErrorHandler(errorEventName: string) {
+  return (syntheticEvent: NativeSyntheticEvent<any>) => {
+    const { nativeEvent } = syntheticEvent;
+    Errors.handle(new ProvenanceWebviewError(errorEventName, nativeEvent));
+  };
+}

--- a/src/services/Errors.tsx
+++ b/src/services/Errors.tsx
@@ -1,0 +1,22 @@
+const tag = '[Provenance] ';
+
+const handle = (error: Error | String) => {
+  // @TODO:
+  // 1. If a onError callback is registered by the client app - call it
+  // 2. Possibly notify us about this
+  console.error(tag + error);
+};
+
+const warn = (message: string) => {
+  console.warn(tag + message);
+};
+
+const info = (message: string) => {
+  console.log(tag + message);
+};
+
+const debug = (message: string) => {
+  console.debug(tag + message);
+};
+
+export { handle, warn, debug, info };

--- a/src/services/Errors.tsx
+++ b/src/services/Errors.tsx
@@ -1,10 +1,19 @@
+let onError: OnErrorCallback | undefined;
+
 const tag = '[Provenance] ';
 
-const handle = (error: Error | String) => {
-  // @TODO:
-  // 1. If a onError callback is registered by the client app - call it
-  // 2. Possibly notify us about this
+const handle = (error: Error | string) => {
+  // @TODO: Maybe notify us about this
   console.error(tag + error);
+  if (onError) {
+    try {
+      onError(error);
+    } catch (e) {
+      console.error(
+        `Error happened in the custom onError callback you provided ${e}. Please fix it`
+      );
+    }
+  }
 };
 
 const warn = (message: string) => {
@@ -19,4 +28,9 @@ const debug = (message: string) => {
   console.debug(tag + message);
 };
 
-export { handle, warn, debug, info };
+export type OnErrorCallback = (error: Error | string) => void;
+const setOnErrorCallback = (callback: OnErrorCallback) => {
+  onError = callback;
+};
+
+export { handle, warn, debug, info, setOnErrorCallback };

--- a/src/trustBadge/index.tsx
+++ b/src/trustBadge/index.tsx
@@ -19,6 +19,7 @@ import {
 import { ProofPoint } from './ProofPoint';
 import { useOffers } from '../hooks/useOffers';
 import { getClaimIcons } from '../utils';
+import ErrorBoundary from '../ErrorBoundary';
 
 type TrustBadgeProps = {
   bundleId: string;
@@ -31,14 +32,22 @@ type TrustBadgeProps = {
 
 const supportedVariants = ['Tick', 'ProofPoint'];
 
-export default function TrustBadge({
+export default function TrustBadge(props: TrustBadgeProps) {
+  return (
+    <ErrorBoundary>
+      <TrustBadgeComponent {...props} />
+    </ErrorBoundary>
+  );
+}
+
+const TrustBadgeComponent = ({
   bundleId,
   sku,
   onPress,
   overlay = true,
   overlayHeight,
   variant = 'Tick',
-}: TrustBadgeProps) {
+}: TrustBadgeProps) => {
   const [showWebview, setShowWebview] = React.useState(false);
   const { height } = useWindowDimensions();
 
@@ -140,7 +149,7 @@ export default function TrustBadge({
       </View>
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   flex: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "@provenance/react-native-provenance": ["./src/index"]
+      "@provenance/react-native-provenance": ["./src/index"],
+      "@src/*": ["./src/*"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,6 +3181,7 @@ __metadata:
     "@testing-library/react-native": ^12.6.1
     "@types/jest": ^29.5.5
     "@types/react": ^18.2.44
+    babel-plugin-module-resolver: ^5.0.2
     commitlint: ^17.0.2
     del-cli: ^5.1.0
     eslint: ^8.51.0


### PR DESCRIPTION
Since our package will be included in client apps, we want to be really careful to not crash them when something goes wrong.

1. If a runtime error happens it is caught so that it doesn't crash the app
2. Every error is logged so that client apps developers can see them and act accordingly
3. `onError` callback can be provided so that the client apps could do own error handling. For instance hide bundle or our components if they are broken or report the errors into their error tracking software.