### PR TITLE
Proof point scales font size RIS-531

### DIFF
--- a/src/bundle/index.tsx
+++ b/src/bundle/index.tsx
@@ -48,8 +48,17 @@ function BundleComponent({
     React.useState(loadingHeight);
   const webview = React.useRef<WebView | null>(null);
 
-  const normalizedScale = Math.max(Math.min(fontScale, 1.25), 1.0);
-  const scalingStatement = `document.body.style.zoom = ${normalizedScale};`;
+  const normalizedScale = Math.max(Math.min(fontScale, 2.0), 1.0);
+  const maxModalZoom = 1.3;
+  const normalizedModalZoom =
+    normalizedScale > 1 ? maxModalZoom / normalizedScale : 'reset';
+  const scalingStatement = `
+    document.body.style.zoom = ${normalizedScale};
+    const style = document.createElement('style');
+    style.type = 'text/css';
+    style.appendChild(document.createTextNode('.ProvenanceModal { zoom: ${normalizedModalZoom}; }'));
+    document.head.appendChild(style);
+  `;
   React.useEffect(() => {
     if (webview.current) {
       webview.current.injectJavaScript(`

--- a/src/trustBadge/Statement/index.tsx
+++ b/src/trustBadge/Statement/index.tsx
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    columnGap: 3,
+    gap: 3,
   },
   contentProvenanceLogo: {
     textTransform: 'uppercase',


### PR DESCRIPTION
### Before

<img width="368" alt="Screenshot 2024-10-01 at 16 14 00" src="https://github.com/user-attachments/assets/2e2355b1-6f46-42cf-9112-c391a192f40b">

### After

![BundleResizingDemo2024-10-01 at 21 27 23](https://github.com/user-attachments/assets/dcaaa20c-e6cd-45bb-bf20-116c2a7b7028)


Better quality on the comment: https://linear.app/provenance/issue/RIS-531/[accessibility]-proofpointbundle-responds-to-system-font-size-changes#comment-bc313437 

## Dependencies

https://github.com/ProjectProvenance/provenance-app/pull/1107 - has to be merged for this to work
