### PR TITLE
fix: chevron alignment in TrustBadge

### DIFF
--- a/src/trustBadge/Capsule/index.tsx
+++ b/src/trustBadge/Capsule/index.tsx
@@ -1,5 +1,5 @@
 import React, { type FC, type ReactNode } from 'react';
-import { View, StyleSheet, Text } from 'react-native';
+import { Platform, View, StyleSheet, Text } from 'react-native';
 import { useScaled } from '../../hooks/useScaled';
 
 export const defaultHeight = 32;
@@ -48,8 +48,8 @@ const styles = StyleSheet.create({
   },
   chevron: {
     color: '#0A3942',
-    fontSize: 26,
-    marginTop: -4,
+    ...(Platform.OS === 'ios' && { fontSize: 24 }),
+    marginTop: Platform.OS === 'ios' ? -4 : -8,
     paddingHorizontal: 4,
   },
 });

--- a/src/trustBadge/Capsule/index.tsx
+++ b/src/trustBadge/Capsule/index.tsx
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
   },
   chevron: {
     color: '#0A3942',
-    ...(Platform.OS === 'ios' && { fontSize: 24 }),
+    fontSize: Platform.OS === 'ios' ? 24 : 14,
     marginTop: Platform.OS === 'ios' ? -4 : -8,
     paddingHorizontal: 4,
   },

--- a/src/trustBadge/Capsule/index.tsx
+++ b/src/trustBadge/Capsule/index.tsx
@@ -51,5 +51,6 @@ const styles = StyleSheet.create({
     fontSize: Platform.OS === 'ios' ? 24 : 14,
     marginTop: Platform.OS === 'ios' ? -4 : -8,
     paddingHorizontal: 4,
+    ...(Platform.OS === 'android' && { transform: 'scale(2)' }),
   },
 });


### PR DESCRIPTION
Follow-up of #23.

Linear task: [RIS-999](https://linear.app/provenance/issue/RIS-999/react-native-chevron-sign-doesnt-scale-well-on-android)

## Demos

### Android

https://github.com/user-attachments/assets/04ba9557-3a56-494a-b2ab-c0970e9deb48

### iOS

https://github.com/user-attachments/assets/39c2223c-b330-4049-832e-35738028fc98