### PR TITLE
fix: iOS home element overlapping bundle content in default modal

### DIFF
--- a/src/trustBadge/index.tsx
+++ b/src/trustBadge/index.tsx
@@ -84,7 +84,7 @@ const TrustBadgeComponent = ({
   React.useEffect(() => {
     if (showWebview) {
       Animated.timing(growAnim, {
-        toValue: containerHeight,
+        toValue: containerHeight + styles.modalContainer.paddingBottom,
         easing: Easing.ease,
         duration: 350,
         useNativeDriver: false,
@@ -158,6 +158,7 @@ const styles = StyleSheet.create({
   modalContainer: {
     height: bundleLoadingHeight,
     borderTopWidth: 1,
+    backgroundColor: 'white',
     borderColor: '#EDEDED',
     shadowColor: '#000',
     shadowOffset: {
@@ -167,5 +168,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: 24,
     elevation: 3,
+    paddingBottom: 12,
   },
 });


### PR DESCRIPTION
Android on the left, iOS on the right

<img width="813" alt="Screenshot 2025-03-18 at 11 05 17" src="https://github.com/user-attachments/assets/b6ba8111-5f07-41cd-8284-3596ea3816d7" />


PE-1346